### PR TITLE
fixed some vulnerabilities which can cause ptunnel-ng to crash

### DIFF
--- a/src/pdesc.c
+++ b/src/pdesc.c
@@ -56,7 +56,7 @@
  * the descriptor chain. If the sock argument is 0, the function will establish
  * a TCP connection to the ip and port given by dst_ip, dst_port.
  */
-proxy_desc_t* create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
+proxy_desc_t *create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
                                            int sock, struct sockaddr_in *addr,
 			                               uint32_t dst_ip, uint32_t dst_port,
                                            uint32_t init_state, uint32_t type) {

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -170,20 +170,19 @@ void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *a
 						else
 							init_state  = kProto_data;
 
-						cur = (proxy_desc_t*) create_and_insert_proxy_desc(pt_pkt->id_no, pkt->identifier, 0,
+						cur = (proxy_desc_t *) create_and_insert_proxy_desc(pt_pkt->id_no, pkt->identifier, 0,
 						                                   addr, pt_pkt->dst_ip,
 						                                   ntohl(pt_pkt->dst_port),
 						                                   init_state, kProxy_flag);
 					       if (!cur) {
 							/* if failed, abort. Logging is done in create_insert_proxy_desc */
-							pt_log(kLog_info, "failed to create proxy descriptor\n");
+							pt_log(kLog_error, "Failed to create proxy descriptor!\n");
 							return;
 						}
 						if (init_state == kProto_authenticate) {
 							pt_log(kLog_debug, "Sending authentication challenge..\n");
 							/* Send challenge */
 							cur->challenge  = generate_challenge();
-							pt_log(kLog_debug, "Challenge generated\n");
 							memcpy(cur->buf, cur->challenge, sizeof(challenge_t));
 							queue_packet(icmp_sock, cur->pkt_type, cur->buf,
 							             sizeof(challenge_t), cur->id_no,


### PR DESCRIPTION
Hi,
I found two bugs in ptunnel-ng that can be misused to crash ptunnel-ng.
1. If a packet with invalid state is sent, reference to state_name[BIG_NUMBER_HERE] will cause ptunnel to crash when it tries to read from invalid memory addresses.

2. When a proxy descriptor is created (as proxy), and fails because it reached max tunnels, it does not calloc a proxy_desc_t cur. The code will later fail in handle_pkt when the null pointer cur is referenced.
