### PR TITLE
fix NAT compatibility

### DIFF
--- a/src/ptunnel.c
+++ b/src/ptunnel.c
@@ -629,6 +629,7 @@ void* pt_proxy(void *args) {
 			if (cur->send_ring[idx].pkt && cur->send_ring[idx].last_resend+kResend_interval < now) {
 				pt_log(kLog_debug, "Resending packet with seq-no %d.\n", cur->send_ring[idx].seq_no);
 				cur->send_ring[idx].last_resend   = now;
+				cur->send_ring[idx].pkt->identifier = htons(cur->icmp_id);
 				cur->send_ring[idx].pkt->seq      = htons(cur->ping_seq);
 				cur->ping_seq++;
 				cur->send_ring[idx].pkt->checksum = 0;


### PR DESCRIPTION
Lost packets are resent using the ICMP identifier of the original packet, which is problematic when NAT uses the ICMP identifier to associate related packets in a ping session. If NAT changes the ICMP identifier in the middle of a ptunnel connection, packets which are resent with wrong ICMP identifiers become disassociated from the ptunnel data stream and the connection breaks.

This fix updates the ICMP identifier of resent packets.