### PR TITLE
command line options for protocol tuning

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -384,7 +384,7 @@ int parse_options(int argc, char **argv) {
          *        since you have to pass long options as '--option=value'. Commonly used
          *        '--option value' is *NOT* allowed for some libc implementations.
          */
-		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::w:a:t:h", &long_options[0], &oidx);
+		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::w:a:t:y:h", &long_options[0], &oidx);
 		if (c == -1) break;
 
 		switch (c) {
@@ -547,6 +547,11 @@ int parse_options(int argc, char **argv) {
 				if (!optarg)
 					break;
 				opts.resend_interval = atoi(optarg);
+				break;
+			case 'y':
+				if (!optarg)
+					break;
+				opts.payload_size = atoi(optarg);
 				break;
 			case 'h':
 				print_usage(argv[0]);

--- a/src/options.c
+++ b/src/options.c
@@ -380,7 +380,7 @@ int parse_options(int argc, char **argv) {
 
 	/* parse command line arguments */
 	while (1) {
-		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::h", &long_options[0], &oidx);
+		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::w:a:t:h", &long_options[0], &oidx);
 		if (c == -1) break;
 
 		switch (c) {
@@ -529,6 +529,21 @@ int parse_options(int argc, char **argv) {
 				pt_log(kLog_error, "SeLinux: %s\n", "feature not supported");
 				exit(1);
 #endif
+			case 'w':
+				if (!optarg)
+					break;
+				opts.window_size = atoi(optarg);
+				break;
+			case 'a':
+				if (!optarg)
+					break;
+				opts.ack_interval = atoi(optarg);
+				break;
+			case 't':
+				if (!optarg)
+					break;
+				opts.resend_interval = atoi(optarg);
+				break;
 			case 'h':
 				print_usage(argv[0]);
 				exit(EXIT_SUCCESS);

--- a/src/options.c
+++ b/src/options.c
@@ -144,7 +144,7 @@ static const struct option_usage usage[] = {
 	/** --ack-interval */
 	{"milliseconds", 0, OPT_DEC32,  {.unum = 1000},
 		"Tune the explicit acknowledgement interval (in milliseconds)\n"
-		"Decreasing the acknowlegement interval can improve NAT stability.\n"
+		"Decreasing the acknowledgement interval can improve NAT stability.\n"
 	},
 	/** --resend-interval */
 	{"milliseconds", 0, OPT_DEC32,  {.unum = 1500},
@@ -156,6 +156,11 @@ static const struct option_usage usage[] = {
 		"Tune the amount of data per packet (in bytes)\n"
 		"Decreasing the payload size can avoid corruption of large packets.\n"
 		"Increasing the payload size can compensate for out-of-order delivery.\n"
+	},
+	/** --empty-pings */
+	{"count",        0, OPT_DEC32,  {.unum = 0},
+		"Tune the number of empty pings to send with each explicit acknowledgement.\n"
+		"Empty pings can compensate for ICMP sequence number inspection.\n"
 	},
 	/** --daemon */
 	{"pidfile",      0, OPT_STR,    {.str = "/run/ptunnel.pid"},
@@ -223,6 +228,7 @@ static struct option long_options[] = {
 	{"ack-interval", required_argument, 0, 'a'},
 	{"resend-interval", required_argument, 0, 't'},
 	{"payload-size", required_argument, 0, 'y'},
+	{"empty-pings", required_argument, 0, 'E'},
 	{"daemon",      optional_argument, 0, 'd'},
 	{"syslog",            no_argument, 0, 'S'},
 	{"user",        optional_argument, 0, 'u'},
@@ -409,7 +415,7 @@ int parse_options(int argc, char **argv) {
          *        since you have to pass long options as '--option=value'. Commonly used
          *        '--option value' is *NOT* allowed for some libc implementations.
          */
-		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::w:a:t:y:h", &long_options[0], &oidx);
+		c = getopt_long(argc, argv, "m:p:l:r::R::c:v:L::o::sP:d::Su::g::C::e::w:a:t:y:E:h", &long_options[0], &oidx);
 		if (c == -1) break;
 
 		switch (c) {
@@ -577,6 +583,11 @@ int parse_options(int argc, char **argv) {
 				if (!optarg)
 					break;
 				opts.payload_size = atoi(optarg);
+				break;
+			case 'E':
+				if (!optarg)
+					break;
+				opts.empty_pings = atoi(optarg);
 				break;
 			case 'h':
 				print_usage(argv[0]);

--- a/src/options.c
+++ b/src/options.c
@@ -136,6 +136,27 @@ static const struct option_usage usage[] = {
 		"Unprivileged mode will only work on some systems, and is in general less reliable\n"
 		"than running in privileged mode.\n"
 	},
+	/** --window-size */
+	{"packets",      0, OPT_DEC32,  {.unum = 64},
+		"Tune the number of packets that can be in-flight at the same time.\n"
+		"Increasing the window size will improve the maximum potential bandwidth.\n"
+	},
+	/** --ack-interval */
+	{"milliseconds", 0, OPT_DEC32,  {.unum = 1000},
+		"Tune the explicit acknowledgement interval (in milliseconds)\n"
+		"Decreasing the acknowlegement interval can improve NAT stability.\n"
+	},
+	/** --resend-interval */
+	{"milliseconds", 0, OPT_DEC32,  {.unum = 1500},
+		"Tune the lost packet timeout (in milliseconds)\n"
+		"Decreasing the resend interval can compensate for frequent packet loss.\n"
+	},
+	/** --payload-size */
+	{"bytes",        0, OPT_DEC32,  {.unum = 1024},
+		"Tune the amount of data per packet (in bytes)\n"
+		"Decreasing the payload size can avoid corruption of large packets.\n"
+		"Increasing the payload size can compensate for out-of-order delivery.\n"
+	},
 	/** --daemon */
 	{"pidfile",      0, OPT_STR,    {.str = "/run/ptunnel.pid"},
 #ifdef WIN32
@@ -198,6 +219,10 @@ static struct option long_options[] = {
 	{"passwd",      required_argument, 0, 'P'},
 	{"udp",               no_argument, &opts.udp, 1 },
 	{"unprivileged",      no_argument, &opts.unprivileged, 1 },
+	{"window-size", required_argument, 0, 'w'},
+	{"ack-interval", required_argument, 0, 'a'},
+	{"resend-interval", required_argument, 0, 't'},
+	{"payload-size", required_argument, 0, 'y'},
 	{"daemon",      optional_argument, 0, 'd'},
 	{"syslog",            no_argument, 0, 'S'},
 	{"user",        optional_argument, 0, 'u'},

--- a/src/options.h
+++ b/src/options.h
@@ -92,6 +92,7 @@ struct options {
 	uint16_t ack_interval;
 	uint16_t resend_interval;
 	uint16_t payload_size;
+	uint16_t empty_pings;
 
 #ifndef WIN32
 	/** run as daemon if non zero value */

--- a/src/options.h
+++ b/src/options.h
@@ -88,6 +88,9 @@ struct options {
 	int udp;
 	/** unpriviledged mode */
 	int unprivileged;
+	uint16_t window_size;
+	uint16_t ack_interval;
+	uint16_t resend_interval;
 
 #ifndef WIN32
 	/** run as daemon if non zero value */

--- a/src/options.h
+++ b/src/options.h
@@ -91,6 +91,7 @@ struct options {
 	uint16_t window_size;
 	uint16_t ack_interval;
 	uint16_t resend_interval;
+	uint16_t payload_size;
 
 #ifndef WIN32
 	/** run as daemon if non zero value */

--- a/src/pconfig.h
+++ b/src/pconfig.h
@@ -75,7 +75,7 @@ enum {
 	 * we send. Note that this does not include
 	 * the IP or ICMP headers!
 	 */
-	kDefault_buf_size    = 1024,
+	kDefault_buf_size    = 0xFFFF,
 	/** Type code for echo request and replies */
 	kICMP_echo_request   = 8,
 	kICMP_echo_reply     = 0,

--- a/src/pdesc.c
+++ b/src/pdesc.c
@@ -114,6 +114,7 @@ proxy_desc_t *create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
 	cur->window_size	= 64;
 	cur->ack_interval	= 1.0;
 	cur->resend_interval	= 1.5;
+	memset(cur->extended_options, 0, sizeof(cur->extended_options));
 	cur->send_ring		= calloc(cur->window_size, sizeof(icmp_desc_t));
 	cur->recv_ring		= calloc(cur->window_size, sizeof(forward_desc_t *));
 	return cur;

--- a/src/pdesc.c
+++ b/src/pdesc.c
@@ -114,6 +114,7 @@ proxy_desc_t *create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
 	cur->window_size	= opts.window_size ? opts.window_size : 64;
 	cur->ack_interval	= opts.ack_interval ? opts.ack_interval / 1000.0 : 1.0;
 	cur->resend_interval	= opts.resend_interval ? opts.resend_interval / 1000.0 : 1.5;
+	cur->payload_size	= opts.payload_size ? opts.payload_size : 1024;
 	memset(cur->extended_options, 0, sizeof(cur->extended_options));
 	cur->send_ring		= calloc(cur->window_size, sizeof(icmp_desc_t));
 	cur->recv_ring		= calloc(cur->window_size, sizeof(forward_desc_t *));

--- a/src/pdesc.c
+++ b/src/pdesc.c
@@ -111,9 +111,9 @@ proxy_desc_t *create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
 	pthread_mutex_unlock(&chain_lock);
 	cur->xfer.bytes_in      = 0.0;
 	cur->xfer.bytes_out     = 0.0;
-	cur->window_size	= 64;
-	cur->ack_interval	= 1.0;
-	cur->resend_interval	= 1.5;
+	cur->window_size	= opts.window_size ? opts.window_size : 64;
+	cur->ack_interval	= opts.ack_interval ? opts.ack_interval / 1000.0 : 1.0;
+	cur->resend_interval	= opts.resend_interval ? opts.resend_interval / 1000.0 : 1.5;
 	memset(cur->extended_options, 0, sizeof(cur->extended_options));
 	cur->send_ring		= calloc(cur->window_size, sizeof(icmp_desc_t));
 	cur->recv_ring		= calloc(cur->window_size, sizeof(forward_desc_t *));

--- a/src/pdesc.c
+++ b/src/pdesc.c
@@ -111,6 +111,11 @@ proxy_desc_t *create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
 	pthread_mutex_unlock(&chain_lock);
 	cur->xfer.bytes_in      = 0.0;
 	cur->xfer.bytes_out     = 0.0;
+	cur->window_size	= 64;
+	cur->ack_interval	= 1.0;
+	cur->resend_interval	= 1.5;
+	cur->send_ring		= calloc(cur->window_size, sizeof(icmp_desc_t));
+	cur->recv_ring		= calloc(cur->window_size, sizeof(forward_desc_t *));
 	return cur;
 }
 
@@ -130,7 +135,7 @@ void remove_proxy_desc(proxy_desc_t *cur, proxy_desc_t *prev) {
 	if (cur->buf)
 		free(cur->buf);
 	cur->buf    = 0;
-	for (i=0;i<kPing_window_size;i++) {
+	for (i=0;i<cur->window_size;i++) {
 		if (cur->send_ring[i].pkt)
 			free(cur->send_ring[i].pkt);
 		cur->send_ring[i].pkt   = 0;
@@ -138,6 +143,8 @@ void remove_proxy_desc(proxy_desc_t *cur, proxy_desc_t *prev) {
 			free(cur->recv_ring[i]);
 		cur->recv_ring[i]       = 0;
 	}
+	free(cur->send_ring);
+	free(cur->recv_ring);
 	close(cur->sock);
 	cur->sock   = 0;
 
@@ -171,7 +178,7 @@ int queue_packet(int icmp_sock, uint8_t type, char *buf, int num_bytes,
                  uint16_t id_no, uint16_t icmp_id, uint16_t *seq, icmp_desc_t ring[],
                  int *insert_idx, int *await_send, uint32_t ip, uint32_t port,
                  uint32_t state, struct sockaddr_in *dest_addr, uint16_t next_expected_seq,
-                 int *first_ack, uint16_t *ping_seq)
+                 int *first_ack, uint16_t *ping_seq, uint16_t window_size)
 {
 	int pkt_len         = sizeof(icmp_echo_packet_t) +
 	                      sizeof(ping_tunnel_pkt_t) + num_bytes;
@@ -233,7 +240,7 @@ int queue_packet(int icmp_sock, uint8_t type, char *buf, int num_bytes,
 		*first_ack             = *insert_idx;
 	(*await_send)++;
 	(*insert_idx)++;
-	if (*insert_idx >= kPing_window_size)
+	if (*insert_idx >= window_size)
 		*insert_idx	= 0;
 	return 0;
 }
@@ -241,7 +248,7 @@ int queue_packet(int icmp_sock, uint8_t type, char *buf, int num_bytes,
 /* send_packets:
  * Examines the passed-in ring, and forwards data in it over TCP.
  */
-uint32_t send_packets(forward_desc_t *ring[], int *xfer_idx, int *await_send, int *sock)   {
+uint32_t send_packets(forward_desc_t *ring[], int *xfer_idx, int *await_send, int *sock, uint16_t window_size)   {
 	forward_desc_t *fwd_desc;
 	int            bytes, total = 0;
 
@@ -267,7 +274,7 @@ uint32_t send_packets(forward_desc_t *ring[], int *xfer_idx, int *await_send, in
 			free(fwd_desc);
 			(*xfer_idx)++;
 			(*await_send)--;
-			if (*xfer_idx >= kPing_window_size)
+			if (*xfer_idx >= window_size)
 				*xfer_idx = 0;
 		}
 		else

--- a/src/pdesc.h
+++ b/src/pdesc.h
@@ -159,6 +159,7 @@ typedef struct proxy_desc_t {
 	uint16_t window_size;
 	double ack_interval;
 	double resend_interval;
+	uint16_t extended_options[3];
     icmp_desc_t *send_ring;
     forward_desc_t **recv_ring;
     xfer_stats_t xfer;

--- a/src/pdesc.h
+++ b/src/pdesc.h
@@ -159,7 +159,8 @@ typedef struct proxy_desc_t {
 	uint16_t window_size;
 	double ack_interval;
 	double resend_interval;
-	uint16_t extended_options[3];
+	uint16_t payload_size;
+	uint16_t extended_options[4];
     icmp_desc_t *send_ring;
     forward_desc_t **recv_ring;
     xfer_stats_t xfer;

--- a/src/pdesc.h
+++ b/src/pdesc.h
@@ -175,6 +175,8 @@ proxy_desc_t*   create_and_insert_proxy_desc(uint16_t id_no, uint16_t icmp_id,
 
 void            remove_proxy_desc(proxy_desc_t *cur, proxy_desc_t *prev);
 
+void            remove_proxy_desc_rings(proxy_desc_t *cur);
+
 forward_desc_t* create_fwd_desc(uint16_t seq_no, uint32_t data_len, char *data);
 
 int             queue_packet(int icmp_sock, uint8_t type, char *buf, int num_bytes,

--- a/src/pdesc.h
+++ b/src/pdesc.h
@@ -156,8 +156,11 @@ typedef struct proxy_desc_t {
 	double last_ack;
 	/** Time when a packet was last received. */
 	double last_activity;
-    icmp_desc_t send_ring[kPing_window_size];
-    forward_desc_t *recv_ring[kPing_window_size];
+	uint16_t window_size;
+	double ack_interval;
+	double resend_interval;
+    icmp_desc_t *send_ring;
+    forward_desc_t **recv_ring;
     xfer_stats_t xfer;
     struct proxy_desc_t *next;
 } proxy_desc_t;
@@ -176,8 +179,8 @@ int             queue_packet(int icmp_sock, uint8_t type, char *buf, int num_byt
                              uint16_t id_no, uint16_t icmp_id, uint16_t *seq, icmp_desc_t ring[],
                              int *insert_idx, int *await_send, uint32_t ip, uint32_t port,
                              uint32_t state, struct sockaddr_in *dest_addr, uint16_t next_expected_seq,
-                             int *first_ack, uint16_t *ping_seq);
+                             int *first_ack, uint16_t *ping_seq, uint16_t window_size);
 
-uint32_t        send_packets(forward_desc_t *ring[], int *xfer_idx, int *await_send, int *sock);
+uint32_t        send_packets(forward_desc_t *ring[], int *xfer_idx, int *await_send, int *sock, uint16_t window_size);
 
 #endif

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -96,6 +96,7 @@ void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *a
 		if (ntohl(pt_pkt->magic) == opts.magic) {
 			pt_pkt->state       = ntohl(pt_pkt->state);
 			pkt->identifier     = ntohs(pkt->identifier);
+			pkt->seq            = ntohs(pkt->seq);
 			pt_pkt->id_no       = ntohs(pt_pkt->id_no);
 			pt_pkt->seq_no      = ntohs(pt_pkt->seq_no);
 			/* Find the relevant connection, if it exists */
@@ -114,8 +115,10 @@ void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *a
 			 */
 			if (cur) {
 				type_flag           = cur->type_flag;
-				if (type_flag == (uint32_t)kProxy_flag)
+				if (type_flag == (uint32_t)kProxy_flag) {
 					cur->icmp_id    = pkt->identifier;
+					cur->ping_seq   = pkt->seq;
+				}
 				if (!is_pcap)
 					cur->xfer.icmp_in++;
 			}

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -361,6 +361,9 @@ void handle_data(icmp_echo_packet_t *pkt, int total_len, forward_desc_t *ring[],
 		if (pt_pkt->data_len >= 6) {
 			cur->extended_options[2] = ntohs(extended_options[2]);
 		}
+		if (pt_pkt->data_len >= 8) {
+			cur->extended_options[3] = ntohs(extended_options[3]);
+		}
 		return;
 	}
 	if (pt_pkt->seq_no == *next_expected_seq) {
@@ -438,6 +441,10 @@ void handle_extended_options(void *vcur)
 	if (cur->extended_options[2] > 0) {
 		cur->resend_interval = cur->extended_options[2] / 1000.0;
 		pt_log(kLog_verbose, "Received extended option for resend interval %f \n", cur->resend_interval);
+	}
+	if (cur->extended_options[3] > 0) {
+		cur->payload_size = cur->extended_options[3];
+		pt_log(kLog_verbose, "Received extended option for payload size %d \n", cur->payload_size);
 	}
 }
 

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -427,9 +427,8 @@ void handle_extended_options(void *vcur)
 {
 	proxy_desc_t *cur = (proxy_desc_t *)vcur;
 	if (cur->extended_options[0] > 0) {
+		remove_proxy_desc_rings(cur);
 		cur->window_size = cur->extended_options[0];
-		free(cur->send_ring);
-		free(cur->recv_ring);
 		cur->send_ring = calloc(cur->window_size, sizeof(icmp_desc_t));
 		cur->recv_ring = calloc(cur->window_size, sizeof(forward_desc_t *));
 		pt_log(kLog_verbose, "Received extended option for window size %d \n", cur->window_size);

--- a/src/pkt.h
+++ b/src/pkt.h
@@ -138,10 +138,10 @@ typedef struct icmp_desc_t icmp_desc_t;
 void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *addr, int icmp_sock);
 
 void handle_data(icmp_echo_packet_t *pkt, int total_len, forward_desc_t **ring,
-                 int *await_send, int *insert_idx,  uint16_t *next_expected_seq);
+                 int *await_send, int *insert_idx,  uint16_t *next_expected_seq, void *cur, uint16_t window_size);
 
 void handle_ack(uint16_t seq_no, icmp_desc_t *ring, int *packets_awaiting_ack,
                 int one_ack_only, int insert_idx, int *first_ack,
-                uint16_t *remote_ack, int is_pcap);
+                uint16_t *remote_ack, int is_pcap, uint16_t window_size);
 
 #endif

--- a/src/pkt.h
+++ b/src/pkt.h
@@ -138,7 +138,9 @@ typedef struct icmp_desc_t icmp_desc_t;
 void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *addr, int icmp_sock);
 
 void handle_data(icmp_echo_packet_t *pkt, int total_len, forward_desc_t **ring,
-                 int *await_send, int *insert_idx,  uint16_t *next_expected_seq, void *cur, uint16_t window_size);
+                 int *await_send, int *insert_idx,  uint16_t *next_expected_seq, void *vcur, uint16_t window_size);
+
+void handle_extended_options(void *vcur);
 
 void handle_ack(uint16_t seq_no, icmp_desc_t *ring, int *packets_awaiting_ack,
                 int one_ack_only, int insert_idx, int *first_ack,

--- a/src/ptunnel.c
+++ b/src/ptunnel.c
@@ -557,23 +557,29 @@ void* pt_proxy(void *args) {
 			if (cur->state == kProxy_start) {
 				pt_log(kLog_verbose, "Sending proxy request.\n");
 				cur->last_ack = time_as_double();
-				uint16_t *extended_options = 0;
+				uint16_t extended_options[4];
 				size_t extended_options_size = 0;
-				if (opts.window_size || opts.ack_interval || opts.resend_interval || opts.payload_size) {
-					extended_options = calloc(4, sizeof(uint16_t));
-					extended_options_size = 4*sizeof(uint16_t);
+				memset(extended_options, 0, sizeof(extended_options));
+				if (opts.window_size) {
+					extended_options_size = sizeof(uint16_t);
 					extended_options[0] = htons(opts.window_size);
+				}
+				if (opts.ack_interval) {
+					extended_options_size = 2*sizeof(uint16_t);
 					extended_options[1] = htons(opts.ack_interval);
+				}
+				if (opts.resend_interval) {
+					extended_options_size = 3*sizeof(uint16_t);
 					extended_options[2] = htons(opts.resend_interval);
+				}
+				if (opts.payload_size) {
+					extended_options_size = 4*sizeof(uint16_t);
 					extended_options[3] = htons(opts.payload_size);
 				}
 				queue_packet(fwd_sock, cur->pkt_type, (char *)extended_options, extended_options_size, cur->id_no, cur->id_no,
 				             &cur->my_seq, cur->send_ring, &cur->send_idx, &cur->send_wait_ack,
 				             cur->dst_ip, cur->dst_port, cur->state | cur->type_flag,
 				             &cur->dest_addr, cur->next_remote_seq, &cur->send_first_ack, &cur->ping_seq, cur->window_size);
-				if (extended_options) {
-					free(extended_options);
-				}
 				cur->xfer.icmp_out++;
 				cur->state = kProto_data;
 			}

--- a/src/ptunnel.c
+++ b/src/ptunnel.c
@@ -558,14 +558,22 @@ void* pt_proxy(void *args) {
 			if (cur->state == kProxy_start) {
 				pt_log(kLog_verbose, "Sending proxy request.\n");
 				cur->last_ack = time_as_double();
-				uint16_t extended_options[3];
-				extended_options[0] = htons(cur->window_size);
-				extended_options[1] = htons(cur->ack_interval*1000);
-				extended_options[2] = htons(cur->resend_interval*1000);
-				queue_packet(fwd_sock, cur->pkt_type, (char *)extended_options, sizeof(extended_options), cur->id_no, cur->id_no,
+				uint16_t *extended_options = 0;
+				size_t extended_options_size = 0;
+				if (opts.window_size || opts.ack_interval || opts.resend_interval) {
+					extended_options = calloc(3, sizeof(uint16_t));
+					extended_options_size = 3*sizeof(uint16_t);
+					extended_options[0] = htons(opts.window_size);
+					extended_options[1] = htons(opts.ack_interval);
+					extended_options[2] = htons(opts.resend_interval);
+				}
+				queue_packet(fwd_sock, cur->pkt_type, (char *)extended_options, extended_options_size, cur->id_no, cur->id_no,
 				             &cur->my_seq, cur->send_ring, &cur->send_idx, &cur->send_wait_ack,
 				             cur->dst_ip, cur->dst_port, cur->state | cur->type_flag,
 				             &cur->dest_addr, cur->next_remote_seq, &cur->send_first_ack, &cur->ping_seq, cur->window_size);
+				if (extended_options) {
+					free(extended_options);
+				}
 				cur->xfer.icmp_out++;
 				cur->state = kProto_data;
 			}


### PR DESCRIPTION
A recompile to change the window size is inconvenient, so I added command line options to tune the protocol. Options are set by the client and sent to the server in the data section of the start packet. The server configures each client connection separately. Multiple clients of the same server can choose different tuning options simultaneously.

```
[-w <packets>] [-a <milliseconds>] [-t <milliseconds>] [-y <bytes>] [-E <count>]

    -w --window-size
        Tune the number of packets that can be in-flight at the same time.
        Increasing the window size will improve the maximum potential bandwidth.
            (default: 64)
    -a --ack-interval
        Tune the explicit acknowledgement interval (in milliseconds)
        Decreasing the acknowledgement interval can improve NAT stability.
            (default: 1000)
    -t --resend-interval
        Tune the lost packet timeout (in milliseconds)
        Decreasing the resend interval can compensate for frequent packet loss.
            (default: 1500)
    -y --payload-size
        Tune the amount of data per packet (in bytes)
        Decreasing the payload size can avoid corruption of large packets.
        Increasing the payload size can compensate for out-of-order delivery.
            (default: 1024)
    -E --empty-pings
        Tune the number of empty pings to send with each explicit acknowledgement.
        Empty pings can compensate for ICMP sequence number inspection.
            (default: 0)
```