### PR TITLE
improvements for empty pings mode

### DIFF
--- a/src/pdesc.h
+++ b/src/pdesc.h
@@ -156,6 +156,7 @@ typedef struct proxy_desc_t {
 	double last_ack;
 	/** Time when a packet was last received. */
 	double last_activity;
+	double last_data_activity;
 	uint16_t window_size;
 	double ack_interval;
 	double resend_interval;

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -297,6 +297,10 @@ void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *a
 				}
 
 				if (cur && cur->sock) {
+					double now = time_as_double();
+					if (pt_pkt->state != kProto_ack) {
+						cur->last_data_activity = now;
+					}
 					if (pt_pkt->state == kProto_data || pt_pkt->state == kProxy_start ||
 					    pt_pkt->state   == kProto_ack)
 					{
@@ -309,7 +313,7 @@ void handle_packet(char *buf, unsigned bytes, int is_pcap, struct sockaddr_in *a
 					handle_ack((uint16_t)pt_pkt->ack, cur->send_ring, &cur->send_wait_ack,
 					           0, cur->send_idx, &cur->send_first_ack, &cur->remote_ack_val,
 					           is_pcap, cur->window_size);
-					cur->last_activity      = time_as_double();
+					cur->last_activity = now;
 				}
 			}
 		}

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -430,10 +430,14 @@ void handle_extended_options(void *vcur)
 {
 	proxy_desc_t *cur = (proxy_desc_t *)vcur;
 	if (cur->extended_options[0] > 0) {
-		remove_proxy_desc_rings(cur);
+		if (cur->extended_options[0] > cur->window_size) {
+			size_t extend = cur->extended_options[0] - cur->window_size;
+			cur->send_ring = realloc(cur->send_ring, cur->extended_options[0] * sizeof(icmp_desc_t));
+			cur->recv_ring = realloc(cur->recv_ring, cur->extended_options[0] * sizeof(forward_desc_t *));
+			memset(cur->send_ring + cur->window_size, 0, extend * sizeof(icmp_desc_t));
+			memset(cur->recv_ring + cur->window_size, 0, extend * sizeof(forward_desc_t *));
+		}
 		cur->window_size = cur->extended_options[0];
-		cur->send_ring = calloc(cur->window_size, sizeof(icmp_desc_t));
-		cur->recv_ring = calloc(cur->window_size, sizeof(forward_desc_t *));
 		pt_log(kLog_verbose, "Received extended option for window size %d \n", cur->window_size);
 	}
 	if (cur->extended_options[1] > 0) {

--- a/src/ptunnel.c
+++ b/src/ptunnel.c
@@ -662,13 +662,15 @@ void* pt_proxy(void *args) {
 			    cur->remote_ack_val+1 != cur->next_remote_seq)
 			{
 				idx = cur->send_idx;
-				cur->last_ack = now;
 				queue_packet(fwd_sock, cur->pkt_type, 0, 0, cur->id_no, cur->icmp_id,
 				             &cur->my_seq, cur->send_ring, &cur->send_idx, &cur->send_wait_ack,
 				             cur->dst_ip, cur->dst_port, kProto_ack | cur->type_flag,
 				             &cur->dest_addr, cur->next_remote_seq, &cur->send_first_ack, &cur->ping_seq, cur->window_size);
 				cur->xfer.icmp_ack_out++;
-				if (cur->send_ring[idx].pkt_len > sizeof(icmp_echo_packet_t) && cur->send_ring[idx].pkt->type == kICMP_echo_request) {
+				if (opts.empty_pings &&
+					cur->last_data_activity > cur->last_ack &&
+					cur->send_ring[idx].pkt_len > sizeof(icmp_echo_packet_t) &&
+					cur->send_ring[idx].pkt->type == kICMP_echo_request) {
 					for (uint16_t e = 0; e < opts.empty_pings; e++) {
 						cur->send_ring[idx].pkt->seq      = htons(cur->ping_seq);
 						cur->ping_seq++;
@@ -678,6 +680,7 @@ void* pt_proxy(void *args) {
 						       0, (struct sockaddr*)&cur->dest_addr, sizeof(struct sockaddr));
 					}
 				}
+				cur->last_ack = now;
 			}
 		}
 		pthread_mutex_unlock(&chain_lock);

--- a/src/ptunnel.c
+++ b/src/ptunnel.c
@@ -672,6 +672,7 @@ void* pt_proxy(void *args) {
 					for (uint16_t e = 0; e < opts.empty_pings; e++) {
 						cur->send_ring[idx].pkt->seq      = htons(cur->ping_seq);
 						cur->ping_seq++;
+						cur->send_ring[idx].pkt->checksum = 0;
 						cur->send_ring[idx].pkt->checksum = htons(calc_icmp_checksum((uint16_t*)cur->send_ring[idx].pkt, sizeof(icmp_echo_packet_t)));
 						sendto(fwd_sock, (const void*)cur->send_ring[idx].pkt, sizeof(icmp_echo_packet_t),
 						       0, (struct sockaddr*)&cur->dest_addr, sizeof(struct sockaddr));


### PR DESCRIPTION
Just a few improvements.

Fixed incorrect checksum on empty pings.

Empty ping requests are not sent when data is not received in ping replies. Only acknowledgements at regular intervals are needed to maintain NAT association when idle.

Send and receive rings are resized when the window size increases, instead of being destroyed and recreated when the window size changed, which was preventing the -E option and the -w option from being used together on a network where ICMP sequence number inspection is enforced.