### PR TITLE
Switch to using /dev/urandom when arc4random is missing

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -164,7 +164,7 @@ int pt_random(void) {
 	static int rng_fd = -1;
 	int rnd_val;
 	if (rng_fd < 0)
-		rng_fd = open("/dev/random", O_RDONLY);
+		rng_fd = open("/dev/urandom", O_RDONLY);
 	assert(rng_fd >= 0);
 	assert( read(rng_fd, &rnd_val, sizeof rnd_val) == sizeof rnd_val );
 	return rnd_val;


### PR DESCRIPTION
/dev/random blocks whereas /dev/urandom does not.

/dev/urandom uses a CSPRNG, which makes it good enough for crypto.

As a sidenote, arc4random uses getrandom on Linux. At least when using libbsd. It may make sense to port the code to use that.